### PR TITLE
Use -f to check if PKGBUILD exists

### DIFF
--- a/mkaurball.in
+++ b/mkaurball.in
@@ -31,7 +31,7 @@ usage() {
 mkaurball() {
   local tarball_basename= tarball_fullname= tmpdir=
 
-  if ! . ./PKGBUILD; then
+  if [[ ! -f ./PKGBUILD ]]; then
     die 'Unable to source %s/PKGBUILD' "$PWD"
   fi
 


### PR DESCRIPTION
Currently if mkaurball is run in a directory without a PKGBUILD it prints

```
/usr/bin/mkaurball: line 200: ./PKGBUILD: No such file or directory
ERROR: Unable to source /home/joel/aur/PKGBUILD
```

With this change it only prints the second line as expected.
