### PR TITLE
mkaurball support '-p <file>' similar to makepkg

### DIFF
--- a/mkaurball.in
+++ b/mkaurball.in
@@ -28,6 +28,7 @@ usage() {
       '    -a <file>  package <file> as .AURINFO' \
       '    -e         edit .AURINFO before repackaging' \
       '    -f         pass the --force flag to makepkg' \
+      '    -p <file>  use <file> as PKGBUILD' \
       '    -h         display this help message and exit'
 }
 
@@ -51,8 +52,9 @@ fakeroot() {
 mkaurball() {
   local tarball_basename= tarball_fullname= tmpdir=
 
-  if ! . ./PKGBUILD; then
-    die 'Unable to source %s/PKGBUILD' "$PWD"
+  pkgbuild=${pkgbuild:-PKGBUILD}
+  if ! . ./${pkgbuild}; then
+    die 'Unable to source %s/%s' "$PWD" "${pkgbuild}"
   fi
 
   if ! makepkg "${makepkg_args[@]}"; then
@@ -93,7 +95,7 @@ mkaurball() {
   fi
 }
 
-while getopts ':a:efh' flag; do
+while getopts ':a:efp:h' flag; do
   case $flag in
     a)
       srcinfo_path=$OPTARG
@@ -103,6 +105,10 @@ while getopts ':a:efh' flag; do
       ;;
     f)
       makepkg_args+=('--force')
+      ;;
+    p)
+      makepkg_args+=("-p$OPTARG")
+      pkgbuild=$OPTARG
       ;;
     h)
       usage


### PR DESCRIPTION
Raised on forum https://bbs.archlinux.org/viewtopic.php?id=183459, this patch provides a `-p` argument to `mkaurball` to allow specifying a different PKGBUILD file. Please consider for merging, much appreciated.
