### PR TITLE
Fixup mksrcinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 /mkaurball
+/mksrcinfo
 /*.log
 /PKGBUILD
 /.AURINFO

--- a/mksrcinfo.in
+++ b/mksrcinfo.in
@@ -15,6 +15,10 @@ usage() {
       '    -o <file>         write output to <file>'
 }
 
+error() {
+  printf "ERROR: $1\n" "${@:2}" >&2
+}
+
 die() {
   error "$@"
   exit 1

--- a/mksrcinfo.in
+++ b/mksrcinfo.in
@@ -26,13 +26,17 @@ die() {
 
 srcinfo_dest=$PWD/.SRCINFO
 
-while getopts ':o:' flag; do
+while getopts ':o:h' flag; do
   case $flag in
     o)
       srcinfo_dest=$OPTARG
       ;;
     :)
       die "option '-%s' requires an argument" "$OPTARG"
+      ;;
+    h)
+      usage
+      exit 0
       ;;
     \?)
       die "invalid option -- '-%s' (use -h for help)" "$OPTARG"


### PR DESCRIPTION
This adds a couple of missing things to `mksrcinfo`. `-h` was not implemented and the `error` function used in `die` was missing.

I have also defaulted the output to `stdout` rather than `$PWD/.SRCINFO`. I think this is a better default (and useful to me :)).
