### PR TITLE
restore passing in a pkgbuild path

### DIFF
--- a/mksrcinfo.in
+++ b/mksrcinfo.in
@@ -4,11 +4,11 @@ usage() {
   printf '%s\n' \
       'mksrcinfo v@VERSION@' \
       '' \
-      'mksrcinfo reads from $PWD/pkgbuild and writes an equivalent .SRCINFO.' \
+      'mksrcinfo reads the target PKGBUILD and writes an equivalent .SRCINFO.' \
       'Without passing any arguments, mksrcinfo will read from $PWD/PKGBUILD' \
       'and write to $PWD/.SRCINFO.' \
       '' \
-      'Usage: mksrcinfo [pkgbuild]' \
+      'Usage: mksrcinfo [/path/to/pkgbuild]' \
       '    -h                display this help message and exit' \
       '    -o <file>         write output to <file>'
 }
@@ -59,7 +59,9 @@ shift $(( OPTIND - 1 ))
 srcinfo_tmp=$(mktemp --tmpdir srcinfo.XXXXXX)
 trap 'rm "$srcinfo_tmp"' EXIT
 
-if makepkg ${1:+'-p' "$1"} --printsrcinfo >"$srcinfo_tmp"; then
+pkgbuild=${1:-$PWD/PKGBUILD}
+if (cd "${PKGBUILD%/*}"; makepkg -p "${pkgbuild##*/}" --printsrcinfo) \
+  >"$srcinfo_tmp"; then
   if ! srcinfo_equal "$srcinfo_tmp" "$srcinfo_dest"; then
     # use cat rather than cp or move to handle cases where $srcinfo_dest isn't a
     # regular file (e.g. /dev/stdout).

--- a/mksrcinfo.in
+++ b/mksrcinfo.in
@@ -4,9 +4,11 @@ usage() {
   printf '%s\n' \
       'mksrcinfo v@VERSION@' \
       '' \
-      'mksrcinfo reads from $PWD/PKGBUILD and writes an equivalent .SRCINFO.' \
+      'mksrcinfo reads from $PWD/pkgbuild and writes an equivalent .SRCINFO.' \
+      'Without passing any arguments, mksrcinfo will read from $PWD/PKGBUILD' \
+      'and write to $PWD/.SRCINFO.' \
       '' \
-      'Usage: mksrcinfo [/path/to/pkgbuild]' \
+      'Usage: mksrcinfo [pkgbuild]' \
       '    -h                display this help message and exit' \
       '    -o <file>         write output to <file>'
 }
@@ -57,7 +59,7 @@ shift $(( OPTIND - 1 ))
 srcinfo_tmp=$(mktemp --tmpdir srcinfo.XXXXXX)
 trap 'rm "$srcinfo_tmp"' EXIT
 
-if makepkg --printsrcinfo >"$srcinfo_tmp"; then
+if makepkg ${1:+'-p' "$1"} --printsrcinfo >"$srcinfo_tmp"; then
   if ! srcinfo_equal "$srcinfo_tmp" "$srcinfo_dest"; then
     # use cat rather than cp or move to handle cases where $srcinfo_dest isn't a
     # regular file (e.g. /dev/stdout).


### PR DESCRIPTION
Commit a07cd59cea847d182b500b0b17c7b7c750b3101c removed the option to specify a file in place of a PKGBUILD, but did not remove the option from the "Usage:" line of the help text. As makepkg supports a `-p` switch to do a similar thing, the functionality can be restored completely.

The second commit adds a change of directory, similar to what is described in the aforementioned commit message, to even accept PKGBUILDs in arbitrary directions.
## 

I am aware that I could just use `makepkg` directly, and that ist what I am actually doing in practice. But before switching away, I wanted to leave a pull request fixing the inconsistency with the help text so that others won't be confused like I was. If you instead want to remove the parameter from description entirely, that would be just as fine.
